### PR TITLE
Add commands.execute to apiMock

### DIFF
--- a/src/apiMock.ts
+++ b/src/apiMock.ts
@@ -55,4 +55,9 @@ export default {
       return "";
     },
   },
+  commands: {
+    execute: async (commandName: string, ...args: any[]): Promise<any> => {
+      return "";
+    },
+  },
 };


### PR DESCRIPTION
# Summary

Adds `commands.execute` to `apiMock`.

Related to https://github.com/JackGruber/joplin-plugin-backup/pull/70

# Motivation

The goal of this pull request is partially to allow testing `Backup.start` in the Simple Backup plugin.